### PR TITLE
Improve GitHub guide website

### DIFF
--- a/github-guide/index.html
+++ b/github-guide/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GitHub Guide</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+    <h1>GitHub Guide</h1>
+    <p class="subtitle">Eine anschauliche Einf&uuml;hrung und wie Codex damit arbeitet</p>
+</header>
+<main>
+    <section id="commands">
+        <h2>Grundlegende Begriffe</h2>
+        <div class="accordion">
+            <div class="accordion-item">
+                <button class="accordion-header">Clone</button>
+                <div class="accordion-content">
+                    <p>Mit <code>git clone &lt;URL&gt;</code> holst du ein Repository auf deinen Rechner.</p>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <button class="accordion-header">Commit</button>
+                <div class="accordion-content">
+                    <p>Ein Commit speichert deine &Auml;nderungen. Verwende <code>git commit -m &quot;Nachricht&quot;</code>.</p>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <button class="accordion-header">Push</button>
+                <div class="accordion-content">
+                    <p>Mit <code>git push</code> l&auml;dst du deine Commits zu GitHub hoch.</p>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <button class="accordion-header">Pull</button>
+                <div class="accordion-content">
+                    <p><code>git pull</code> holt neue &Auml;nderungen vom Remote-Repository.</p>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <button class="accordion-header">Branch</button>
+                <div class="accordion-content">
+                    <p>Ein Branch ist ein paralleler Entwicklungszweig. Erstelle ihn mit <code>git checkout -b mein-branch</code>.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="workflow">
+        <h2>Typischer Git-Workflow</h2>
+        <div class="timeline">
+            <div class="step">
+                <div class="circle">1</div>
+                <p>Repository klonen</p>
+            </div>
+            <div class="step">
+                <div class="circle">2</div>
+                <p>Dateien bearbeiten und committen</p>
+            </div>
+            <div class="step">
+                <div class="circle">3</div>
+                <p>Commits zu GitHub pushen</p>
+            </div>
+            <div class="step">
+                <div class="circle">4</div>
+                <p>Neues vom Remote mit pull holen</p>
+            </div>
+            <div class="step">
+                <div class="circle">5</div>
+                <p>Branches &amp; Pull Requests verwenden</p>
+            </div>
+        </div>
+    </section>
+
+    <section id="codex">
+        <h2>Wie Codex GitHub nutzt</h2>
+        <ol class="codex-flow">
+            <li>Repo klonen oder aktualisieren</li>
+            <li>Neuen Branch anlegen und Dateien anpassen</li>
+            <li>Tests ausf&uuml;hren und Ergebnisse sammeln</li>
+            <li>Commit erstellen und Branch pushen</li>
+            <li>Pull Request erzeugen und Zusammenfassung liefern</li>
+        </ol>
+    </section>
+</main>
+<footer>
+    <p>Erstellt als anschauliche Einf&uuml;hrung in GitHub.</p>
+</footer>
+<script src="script.js"></script>
+</body>
+</html>

--- a/github-guide/script.js
+++ b/github-guide/script.js
@@ -1,0 +1,18 @@
+// Einfaches Skript f&uuml;r die Akkordeon-Elemente
+
+function initAccordion() {
+    const headers = document.querySelectorAll('.accordion-header');
+    headers.forEach(h => {
+        h.addEventListener('click', () => {
+            h.classList.toggle('active');
+            const content = h.nextElementSibling;
+            if (content.style.display === 'block') {
+                content.style.display = 'none';
+            } else {
+                content.style.display = 'block';
+            }
+        });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', initAccordion);

--- a/github-guide/style.css
+++ b/github-guide/style.css
@@ -1,0 +1,99 @@
+body {
+    margin: 0;
+    font-family: "Segoe UI", Tahoma, sans-serif;
+    background: linear-gradient(135deg, #8fbcd4, #e3f2fd);
+    color: #333;
+}
+
+header {
+    text-align: center;
+    color: #fff;
+    padding: 40px 20px;
+    background: linear-gradient(160deg, #1e7fbf, #12496a);
+}
+
+.subtitle {
+    margin-top: 10px;
+    font-size: 1.1em;
+}
+
+main {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+h2 {
+    border-bottom: 2px solid #1e7fbf;
+    padding-bottom: 5px;
+}
+
+.accordion-item {
+    border: 1px solid #bbb;
+    border-radius: 4px;
+    margin-bottom: 8px;
+    overflow: hidden;
+}
+
+.accordion-header {
+    width: 100%;
+    text-align: left;
+    background-color: #e8f0f8;
+    border: none;
+    padding: 10px;
+    font-size: 1em;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.accordion-content {
+    display: none;
+    padding: 10px;
+    background-color: #fff;
+}
+
+.timeline {
+    position: relative;
+    padding-left: 30px;
+    margin: 20px 0;
+}
+
+.timeline::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 14px;
+    width: 4px;
+    background: #1e7fbf;
+}
+
+.step {
+    position: relative;
+    margin-bottom: 20px;
+}
+
+.circle {
+    position: absolute;
+    left: -6px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #1e7fbf;
+    color: #fff;
+    text-align: center;
+    line-height: 20px;
+    font-size: 0.9em;
+    font-weight: bold;
+}
+
+.codex-flow {
+    padding-left: 20px;
+}
+
+footer {
+    text-align: center;
+    padding: 20px;
+    color: #fff;
+    background: #12496a;
+}


### PR DESCRIPTION
## Summary
- redesign `github-guide` page with header, sections and timeline
- add interactive accordion to explain Git commands
- style the page with gradients and improved layout
- update JS to handle accordion toggling

## Testing
- `echo "No tests" && true`
